### PR TITLE
fixes #10400 - enforce cwd on psql resources

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -9,6 +9,11 @@ class gutterball::database{
     auth_method => 'password',
   }
 
+  # Prevents errors if run from /root etc.
+  Postgresql_psql {
+    cwd => '/',
+  }
+
   postgresql::server::db { 'gutterball':
     user     => $gutterball::dbuser,
     password => $gutterball::dbpassword,


### PR DESCRIPTION
Looks like the CWD thing:

```
[ WARN 2015-05-07 09:26:32 main]  /Stage[main]/Gutterball::Database/Postgresql::Server::Db[gutterball]/Postgresql::Server::Database[gutterball]/Exec[/usr/bin/createdb --port='5432' --owner='postgres' --template=template0  'gutterball']/returns: could not change directory to "/root"
```

With this, I don't get the gutterball error anymore.
