### PR TITLE
add keystore and truststore files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,8 +5,8 @@ class gutterball::config(
   $dbuser            = $::gutterball::dbuser,
   $dbpass            = $::gutterball::dbpassword,
   $keystore_password = $::gutterball::keystore_password,
+  $truststore_file   = $::gutterball::truststore_file,
 ){
-
   file { '/etc/gutterball':
     ensure => directory,
     mode   => '0775',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,11 +13,17 @@
 #
 # $tomcat::                 The system tomcat to use, tomcat6 on RHEL6 and tomcat on most Fedoras
 #
-# $keystore_password::      Password to keystore and trutstore
+# $keystore_file::          Path to keystore file
 #
-# $amqp_broker_host::      AMQP service's fqdn
+# $keystore_password::      Password for keystore
 #
-# $amqp_broker_port::      AMQP service's port number
+# $truststore_file::        Path to truststore file
+#
+# $truststore_password::    Password for trutstore
+#
+# $amqp_broker_host::       AMQP service's fqdn
+#
+# $amqp_broker_port::       AMQP service's port number
 #
 class gutterball (
   $amqp_broker_host     = $::fqdn,
@@ -25,14 +31,17 @@ class gutterball (
   $gutterball_conf_file = $::gutterball::params::gutterball_conf_file,
   $dbuser               = $::gutterball::params::dbuser,
   $dbpassword           = $::gutterball::params::dbpassword,
+  $keystore_file        = $::gutterball::params::keystore_file,
   $keystore_password    = $::gutterball::params::keystore_password,
+  $truststore_file      = $::gutterball::params::truststore_file,
+  $truststore_password  = $::gutterball::params::truststore_password,
   $tomcat               = $::gutterball::params::tomcat,
 ) inherits gutterball::params {
+  validate_absolute_path([$keystore_file, $truststore_file])
 
   class { '::gutterball::install': } ~>
   class { '::gutterball::config': } ~>
   class { '::gutterball::database': } ~>
   class { '::gutterball::service': } ~>
   Class['gutterball']
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,10 @@ class gutterball::params {
   $gutterball_conf_file = '/etc/gutterball/gutterball.conf'
   $dbuser = 'gutterball'
   $dbpassword = 'gutterball'
+  $keystore_file = '/etc/gutterball/certs/amqp/gutterball.jks'
   $keystore_password = undef
+  $truststore_file = '/etc/gutterball/certs/amqp/gutterball.truststore'
+  $truststore_password = undef
 
   $tomcat = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
@@ -14,5 +17,4 @@ class gutterball::params {
       }
     }
   }
-
 }

--- a/templates/gutterball.conf.erb
+++ b/templates/gutterball.conf.erb
@@ -8,8 +8,11 @@ jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 jpa.config.hibernate.show_sql=false
 
 # password comes from /etc/pki/katello/keystore_password-file
+gutterball.amqp.keystore=<%= @keystore_file %>
 gutterball.amqp.keystore_password=<%= @keystore_password %>
-gutterball.amqp.truststore_password=<%= @keystore_password %>
+gutterball.amqp.truststore=<%= @truststore_file %>
+gutterball.amqp.truststore_password=<%= @truststore_password %>
+
 gutterball.amqp.connect=amqp://guest:guest@<%= @amqp_broker_host %>/test:<%= @amqp_broker_port %>?brokerlist='tcp://<%= @amqp_broker_host %>:<%= @amqp_broker_port %>'&ssl='true'&ssl_cert_alias='gutterball'
 
 log4j.logger.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
Add possibility to define the keystore and truststore files.

Defaults have been taken from here:
https://github.com/candlepin/candlepin/blob/master/gutterball/conf/gutterball.conf